### PR TITLE
Bugfixes and support to keep the app opened

### DIFF
--- a/qml/cover/CoverPage.qml
+++ b/qml/cover/CoverPage.qml
@@ -178,7 +178,7 @@ CoverBackground {
                 var dialog = pageStack.push(Qt.resolvedUrl("../pages/AddItemDialog.qml"), { date: main.today },
                                             PageStackAction.Immediate)
                 dialog.accepted.connect(function() {
-                    addItem(main.today, dialog.text.trim(), dialog.description.trim());
+                    addItem(dialog.date, dialog.text.trim(), dialog.description.trim());
                 });
                 main.activate();
             }

--- a/qml/cover/CoverPage.qml
+++ b/qml/cover/CoverPage.qml
@@ -192,4 +192,9 @@ CoverBackground {
             }
         }
     }
+
+    onStatusChanged: {
+        // Trigger the update check of the date values once the application is resumed.
+        refreshDates();
+    }
 }

--- a/qml/harbour-todolist.qml
+++ b/qml/harbour-todolist.qml
@@ -98,7 +98,6 @@ ApplicationWindow
             if (oldToday !== today) {
                 updated = true;
             }
-
             if (updated) {
                 tomorrow = Helpers.getDate(1);
                 thisweek = Helpers.getDate(0, new Date("8888-01-01T00:00Z"));
@@ -116,9 +115,9 @@ ApplicationWindow
                 setCurrentProject(config.currentProject);
 
                 updated = false;
-                // Start the next check once the next day is reached.
-                interval = tomorrow.getTime() - Date.now();
             }
+            // Start the next check once the next day is reached or in a minute if less.
+            interval = Math.max(tomorrow.getTime() - Date.now(), 60000);
         }
     }
 

--- a/qml/harbour-todolist.qml
+++ b/qml/harbour-todolist.qml
@@ -84,7 +84,7 @@ ApplicationWindow
     Timer {
         id: timer
         repeat: true
-        // Run every 1h to check for changes.
+        // Initally run every 1h to check for changes.
         interval: 3600000
         triggeredOnStart: true
 
@@ -93,7 +93,7 @@ ApplicationWindow
 
         onTriggered: {
             // Reset all date properties after a date change while the application is running.
-            let oldToday = today;
+            var oldToday = today;
             today = Helpers.getDate(0);
             if (oldToday !== today) {
                 updated = true;
@@ -115,11 +115,9 @@ ApplicationWindow
                 Storage.copyRecurrings();
                 setCurrentProject(config.currentProject);
 
-                projectsModel.clear();
-                var projects = Storage.getProjects();
-                for (var i in projects) projectsModel.append(projects[i]);
-
                 updated = false;
+                // Start the next check once the next day is reached.
+                interval = tomorrow.getTime() - Date.now();
             }
         }
     }
@@ -286,5 +284,8 @@ ApplicationWindow
     Component.onCompleted: {
         About.VERSION_NUMBER = VERSION_NUMBER;
         timer.start();
+        projectsModel.clear();
+        var projects = Storage.getProjects();
+        for (var i in projects) projectsModel.append(projects[i]);
     }
 }

--- a/qml/harbour-todolist.qml
+++ b/qml/harbour-todolist.qml
@@ -83,41 +83,11 @@ ApplicationWindow
 
     Timer {
         id: timer
-        repeat: true
-        // Initally run every 1h to check for changes.
+        // Run every 1h to check for changes.
         interval: 3600000
-        triggeredOnStart: true
-
-        // Start with true to trigger a refresh on application startup.
-        property bool updated: true
-
+        repeat: true
         onTriggered: {
-            // Reset all date properties after a date change while the application is running.
-            var oldToday = today;
-            today = Helpers.getDate(0);
-            if (oldToday !== today) {
-                updated = true;
-            }
-            if (updated) {
-                tomorrow = Helpers.getDate(1);
-                thisweek = Helpers.getDate(0, new Date("8888-01-01T00:00Z"));
-                someday = Helpers.getDate(0, new Date("9999-01-01T00:00Z"));
-                todayString = Helpers.getDateString(today);
-                tomorrowString = Helpers.getDateString(tomorrow);
-                thisweekString = Helpers.getDateString(thisweek);
-                somedayString = Helpers.getDateString(someday);
-
-                // Update the database and models according to the new date properties.
-                if (Storage.carryOverFrom(config.lastCarriedOverFrom)) {
-                    config.lastCarriedOverFrom = Helpers.getDate(-1, today);
-                }
-                Storage.copyRecurrings();
-                setCurrentProject(config.currentProject);
-
-                updated = false;
-            }
-            // Start the next check once the next day is reached or in a minute if less.
-            interval = Math.max(tomorrow.getTime() - Date.now(), 60000);
+            refreshDates();
         }
     }
 
@@ -280,11 +250,41 @@ ApplicationWindow
         for (var i in entries) archiveModel.append(entries[i]);
     }
 
+    // Resets all date properties after a date change. The force parameter can be used to force a model refresh.
+    function refreshDates(force) {
+        var oldToday = todayString;
+
+        today = Helpers.getDate(0);
+        todayString = Helpers.getDateString(today);
+
+        // If the date did not change, do not update anything else.
+        if (!force && oldToday === todayString) {
+            return;
+        }
+
+        tomorrow = Helpers.getDate(1);
+        thisweek = Helpers.getDate(0, new Date("8888-01-01T00:00Z"));
+        someday = Helpers.getDate(0, new Date("9999-01-01T00:00Z"));
+        tomorrowString = Helpers.getDateString(tomorrow);
+        thisweekString = Helpers.getDateString(thisweek);
+        somedayString = Helpers.getDateString(someday);
+
+        // Update the database and models according to the new date properties.
+        if (Storage.carryOverFrom(config.lastCarriedOverFrom)) {
+            config.lastCarriedOverFrom = Helpers.getDate(-1, today);
+        }
+        Storage.copyRecurrings();
+        setCurrentProject(config.currentProject);
+    }
+
     Component.onCompleted: {
         About.VERSION_NUMBER = VERSION_NUMBER;
-        timer.start();
+        // Start with true to force a refresh on application startup.
+        refreshDates(true);
         projectsModel.clear();
         var projects = Storage.getProjects();
         for (var i in projects) projectsModel.append(projects[i]);
+        // Start the timer to check for date changes every hour.
+        timer.start();
     }
 }

--- a/qml/js/helpers.js
+++ b/qml/js/helpers.js
@@ -21,8 +21,8 @@
 
 function getDate(offset, baseDate) {
     var currentDate = baseDate === undefined ? new Date() : baseDate;
-    currentDate.setUTCDate(currentDate.getDate() + offset);
-    currentDate.setUTCHours(0, 0, 0, 0);
+    currentDate.setDate(currentDate.getDate() + offset);
+    currentDate.setHours(0, 0, 0, 0);
     return currentDate;
 }
 

--- a/qml/js/storage.js
+++ b/qml/js/storage.js
@@ -240,7 +240,7 @@ function _prepareEntries(q) {
         var item = q.rows.item(i);
 
         res.push({entryId: item.rowid,
-                     date: new Date(item.date),
+                     date: Helpers.getDate(0, new Date(item.date)),
                      entryState: parseInt(item.entryState, 10),
                      subState: parseInt(item.subState, 10),
                      createdOn: new Date(item.createdOn),

--- a/qml/sf-about-page/about.js
+++ b/qml/sf-about-page/about.js
@@ -5,6 +5,7 @@
 
 
 var DEVELOPMENT = [
+    {label: "", values: ["Johannes Bachmann"]},
     // enable when there are other contributors
 ]
 


### PR DESCRIPTION
Hi,

I found some bugs while using the app and also plan to keep it opened all time. So this branch changes the following:
- Fix the planning date selection when added from cover page
- Use the local time to zero hour and minutes
- Do not duplicate section headers for entries from the database
- Add a timer to regularly check if the next day is reached
- Also check for the next day when the application is minimized or resumed

Please apply the changes after evaluation or implement a better solution if available.

Thanks and regards
Dscheinah